### PR TITLE
Balancing changes for hard difficulty and in general

### DIFF
--- a/Assets/Prefab/Enemy/Bacteria.prefab
+++ b/Assets/Prefab/Enemy/Bacteria.prefab
@@ -104,7 +104,7 @@ MonoBehaviour:
   distanceToTurn: 0.05
   maxHealthEasy: 30
   maxHealthMedium: 50
-  maxHealthHard: 70
+  maxHealthHard: 75
   maxHealthColor: {r: 1, g: 0.29411766, b: 0.2784314, a: 0}
   minHealthColor: {r: 1, g: 0.39782178, b: 0.2588235, a: 0}
   deathSound: {fileID: 8300000, guid: e91aad6325856ad439d4f4bda4eceedb, type: 3}

--- a/Assets/Prefab/Enemy/Pathogen.prefab
+++ b/Assets/Prefab/Enemy/Pathogen.prefab
@@ -99,12 +99,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   reward: 100
-  speed: 2
+  speed: 1.25
   damage: 300
   distanceToTurn: 0.05
   maxHealthEasy: 250
   maxHealthMedium: 400
-  maxHealthHard: 600
+  maxHealthHard: 550
   maxHealthColor: {r: 1, g: 0.83137256, b: 0, a: 0}
   minHealthColor: {r: 1, g: 0.39782178, b: 0.2588235, a: 0}
   deathSound: {fileID: 8300000, guid: e91aad6325856ad439d4f4bda4eceedb, type: 3}

--- a/Assets/Prefab/Enemy/Virus.prefab
+++ b/Assets/Prefab/Enemy/Virus.prefab
@@ -99,12 +99,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   reward: 50
-  speed: 3
+  speed: 2
   damage: 50
   distanceToTurn: 0.05
-  maxHealthEasy: 60
-  maxHealthMedium: 100
-  maxHealthHard: 150
+  maxHealthEasy: 50
+  maxHealthMedium: 75
+  maxHealthHard: 125
   maxHealthColor: {r: 0.3647059, g: 1, b: 0.47843137, a: 0}
   minHealthColor: {r: 1, g: 0.39782178, b: 0.2588235, a: 0}
   deathSound: {fileID: 8300000, guid: e91aad6325856ad439d4f4bda4eceedb, type: 3}

--- a/Assets/Scenes/Levels/Level4.unity.meta
+++ b/Assets/Scenes/Levels/Level4.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c696f1b49a0089b489f2b4a035463a0d
+guid: 92a536284628b1c449f06fcb55ca7a10
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scenes/Levels/Level5.unity.meta
+++ b/Assets/Scenes/Levels/Level5.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c696f1b49a0089b489f2b4a035463a0d
+guid: 059fe2d770f061c4aab360091eecfba3
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/prefab/Turret/Basic/BasicTurret.prefab
+++ b/Assets/prefab/Turret/Basic/BasicTurret.prefab
@@ -164,7 +164,7 @@ MonoBehaviour:
   range: 5
   accuracy: 1
   fireInterval: 1
-  rotationSpeed: 100
+  rotationSpeed: 90
   bullet: {fileID: 616828243655139705, guid: 628f0ebab2d896a4e9f643cba9de1101, type: 3}
   barrel: {fileID: 5689364645152157612}
   shootSound: {fileID: 8300000, guid: 4a92b691d2b536c438429bdb84cd3cbf, type: 3}

--- a/Assets/prefab/Turret/Gatling/GatlingBullet.prefab
+++ b/Assets/prefab/Turret/Gatling/GatlingBullet.prefab
@@ -147,6 +147,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 15
-  damage: 10
+  damage: 8
   pierce: 0
   impact: {fileID: 7975970741664304813, guid: f4f2c742474cb5d40a68e6199e2a1170, type: 3}

--- a/Assets/prefab/Turret/Gatling/GatlingTurret.prefab
+++ b/Assets/prefab/Turret/Gatling/GatlingTurret.prefab
@@ -445,7 +445,7 @@ MonoBehaviour:
   range: 5
   accuracy: 0.7
   fireInterval: 0.1
-  rotationSpeed: 80
+  rotationSpeed: 120
   bullet: {fileID: 616828243655139705, guid: 0f9ee0e61e9ba3347bcad1dd1ec7d2a6, type: 3}
   barrel: {fileID: 5689364645152157612}
   shootSound: {fileID: 8300000, guid: ee7249c77d4105e40b4b8f8279798b95, type: 3}

--- a/Assets/prefab/Turret/Sniper/SniperBullet.prefab
+++ b/Assets/prefab/Turret/Sniper/SniperBullet.prefab
@@ -146,7 +146,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6b11a7bb2c6b15449aecdf44ccb4601, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 80
-  damage: 100
+  speed: 50
+  damage: 110
   pierce: 1
   impact: {fileID: 7975970741664304813, guid: f4f2c742474cb5d40a68e6199e2a1170, type: 3}


### PR DESCRIPTION
Enemies:
-Lowered virus health on hard and normal.
-Lowered virus speed.
-Lowered pathogen health on hard.
-Lowered pathogen speed.
Gatling:
-Nerfed gatling tower a bit to make it deal less damage but turn faster.
Sniper:
+Buffed sniper tower to make bullets deal more damage and register shots more.
~Changed bullet speed for sniper to allow bullet to register targeted enemy hit 100% of the time.